### PR TITLE
Allow manual width and height on images

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -18,9 +18,18 @@ body {
   margin: 0;
 }
 
-img {
+/* Fluid images.
+ */
+img{
   max-width: 100%;
-  height: auto;
+}
+
+/**
+ * Non-fluid images if you specify `width` and/or `height` attributes.
+ */
+img[width],
+img[height]{
+  max-width: none;
 }
 
 svg {


### PR DESCRIPTION
Removes auto height and ignores max-width on images with manual width and height set.
Reference: https://github.com/csswizardry/inuit.css/pull/111#issuecomment-12562366
